### PR TITLE
Ajustes em configuracoes.tex e lista_siglas.tex

### DIFF
--- a/1-pre-textuais/lista_siglas.tex
+++ b/1-pre-textuais/lista_siglas.tex
@@ -4,9 +4,10 @@
 \textbf{\uppercase{Lista de Abreviaturas e Siglas}}
 \end{center}
 \vspace{0.5cm}
+
 \begin{spacing}{2}
 
-\begin{tabular}{ l l }
+\begin{longtable}{ l l }
 \textbf{AI}&Artificial Intelligence\\
 \textbf{CPU}&Central Process Unit\\
 \textbf{FSP}&Feature Space Partition\\
@@ -16,6 +17,6 @@
 \textbf{ML}&Machine Learning\\
 \textbf{PyPI}&Python Package Index\\
 \textbf{SVM}&Support Vector Machine\\
-\end{tabular}
+\end{longtable}
 
 \end{spacing}

--- a/config/configuracoes.tex
+++ b/config/configuracoes.tex
@@ -35,6 +35,8 @@ right=2cm]{geometry}
 % Necessario para incluir a ficha catalográfica, anexos e apêndices
 \usepackage{pdfpages} 
 
+% Para utilizar tabelas longas e quebrar automaticamente entre páginas
+\usepackage{longtable}
 
 % Usado para remover a quebra de linha nos recuos das folhas de rosto e de aprovação
 \usepackage{hyphenat}                   


### PR DESCRIPTION
Ajusta os elementos flutuantes para que não sejam posicionados em páginas sem texto, mesmo havendo espaço. Isso acontece quando há elementos suficientemente grandes próximos um do outro no texto. Há também o ajuste de quebra automática da lista de siglas com o pacote "longtable", caso a lista de siglas não caiba em apenas uma página.